### PR TITLE
Update pyyaml to 5.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyyaml == 5.4
+pyyaml == 5.4.1

--- a/yamlconf/about.py
+++ b/yamlconf/about.py
@@ -1,5 +1,5 @@
 __name__ = "yamlconf"
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __author__ = "Aaron Halfaker"
 __author_email__ = "aaron.halfaker@gmail.com"
 __description__ = "Yaml-based configuration file reader."


### PR DESCRIPTION
The current version of the package makes it incompatible to use with latest version of  the `kubernetes` package.

The Wikimedia ML team is trying to upgrade the kserve version from 0.8.0 to 0.9.0 and bumped into the following issue:

- kserve==0.9.0 depends on kubernetes>=18.20.0
- the latest version of the kuberenetes package, including 18.20.0 require a pyyaml package version that is >= 5.4.1
Adding pyyaml 5.4.1 as a requirement will resolve this issue.

This PR changes the required version of pyyaml and bumps the package version.